### PR TITLE
Read multiple temperature sensors (DS18B20)

### DIFF
--- a/device/DS18B20.js
+++ b/device/DS18B20.js
@@ -14,14 +14,17 @@ export default class extends Device {
     const { interval } = this.config
 
     this.poll(interval, async () => {
-      this.emitEntity({
-        name: 'Temperatur',
-        key: 'temperature',
-        class: 'temperature',
-        unit: '°C',
-        states: {
-          state: sensor.readSimpleC()?.toFixed(1) || 0
-        }
+      const temps = sensor.readAllC(1);
+      temps.map(({ id, t }) => {
+        this.emitEntity({
+          name: 'Temperatur',
+          key: id,
+          class: 'temperature',
+          unit: '°C',
+          states: {
+            state: t || 0
+          }
+        })
       })
     })
   }


### PR DESCRIPTION
When running with more than one sensor I got an error saying that `readSimpleC` was only allowed if there is exactly one sensor connected. The same library however also has a function for reading many (`readAllC`).

Let me know if you want to make this a config or not. I think it's also fine in case there is only one. It now also returns the identifier to the mqtt broker.